### PR TITLE
fixes url typo, retains spaces in pkg info

### DIFF
--- a/chemgreek.sty
+++ b/chemgreek.sty
@@ -6,7 +6,7 @@
 % --------------------------------------------------------------------------
 % Clemens Niederberger
 % --------------------------------------------------------------------------
-% https://github.org/cgnieder/chemgreek/
+% https://github.com/cgnieder/chemgreek/
 % contact@mychemistry.eu
 % --------------------------------------------------------------------------
 % If you have any ideas, questions, suggestions or bugs to report, please
@@ -30,7 +30,8 @@
 \ExplSyntaxOn
 \tl_const:Nn \c_chemgreek_date_tl {2016/12/20}
 \tl_const:Nn \c_chemgreek_version_tl {1.1}
-\tl_const:Nn \c_chemgreek_info_tl {interface for upright greek letters for use in chemistry}
+\tl_const:Nn \c_chemgreek_info_tl
+  {interface~ for~ upright~ greek~ letters~ for~ use~ in~ chemistry}
 
 \ProvidesExplPackage{chemgreek}
   {\c_chemgreek_date_tl}


### PR DESCRIPTION
1. fixes typo of the url of project repo
2. retains spaces in pkg info, in a style the maintainer used in his other pkgs